### PR TITLE
Promote the ArcaneNibble/mident crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ These projects are free of syn (submit a PR to add yours):
 
   * [facet](https://github.com/facet-rs/facet) is a reflection and serialization/deserialization framework for Rust
   * [xmacro/xmacro_lib](https://docs.rs/xmacro_lib/latest/xmacro_lib/) Proc-Macro engine for templating rust code
+  * [mident](https://github.com/ArcaneNibble/mident) is a toolbox for creating and manipulating identifiers in declarative macros


### PR DESCRIPTION
I came across this movement via the fediverse, and I had the realization that at least some of my unnecessary use of `syn` and `quote` was solely for the purpose of injecting new identifiers, either random unique identifiers or somehow programmatically deriving one from a type path. I decided to refactor most of the logic I was using into a standalone reusable proc macro which doesn't require `syn`, and the result is the `mident` crate.