### PR TITLE
Add maybe_special to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ These projects are free of syn (submit a PR to add yours):
   * [xmacro/xmacro_lib](https://docs.rs/xmacro_lib/latest/xmacro_lib/) Proc-Macro engine for templating rust code
   * [mident](https://github.com/ArcaneNibble/mident) is a toolbox for creating and manipulating identifiers in declarative macros
   * [eager2](https://github.com/Daniel-Aaron-Bloom/eager2) is a framework for eager macro expansion
+  * [maybe_special](https://github.com/pypylia/maybe_special) is an attribute macro to automatically generate target feature specialisations.
+  


### PR DESCRIPTION
[maybe_special](https://github.com/pypylia/maybe_special) is an attribute macro to automatically generate target feature specialisations.
It does not use syn, rather relying on [venial](https://crates.io/crates/venial) and quote, on top of its own parsing for the attribute parameters.